### PR TITLE
fix: always overwrite _knot_files/ artefacts — stale copy bug

### DIFF
--- a/crates/knot-core/src/project.rs
+++ b/crates/knot-core/src/project.rs
@@ -460,7 +460,7 @@ fn fix_paths_in_typst(source: &str, typ_file: &Path) -> Result<String> {
 
         if !processed.contains(filename_os) {
             let dest = local_files_dir.join(filename.as_ref());
-            if abs_path.exists() && !dest.exists() {
+            if abs_path.exists() {
                 let _ = fs::copy(abs_path, &dest);
             }
             processed.insert(filename_os.to_owned());


### PR DESCRIPTION
## Summary

- Removes `!dest.exists()` guard in `fix_paths_in_typst` so artefacts in `_knot_files/` are always overwritten from `.knot_cache/`
- Fixes `fig-width`/`fig-height` changes having no visible effect after the first render

## Test plan

- [x] `knot build` with `fig-width: 4` → PDF shows correct ratio
- [ ] Change to `fig-width: 8`, run `knot build` again → PDF updates to new ratio (was broken before)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)