### PR TITLE
fix: include SCRIPTS_VERSION in chunk hash for automatic cache invalidation

### DIFF
--- a/crates/knot-core/src/cache/hashing.rs
+++ b/crates/knot-core/src/cache/hashing.rs
@@ -18,6 +18,8 @@ use std::path::PathBuf;
 /// - Serialized options (eval, show, cache, graphics, etc.)
 /// - Previous chunk hash (for sequential invalidation)
 /// - Dependencies hash (for file-based invalidation)
+/// - Scripts version (fingerprint of embedded R/Python helpers — ensures
+///   cache entries are invalidated whenever the runtime scripts change)
 pub fn get_chunk_hash(
     code: &str,
     options: &ChunkOptions,
@@ -26,8 +28,12 @@ pub fn get_chunk_hash(
 ) -> String {
     let options_str = serde_json::to_string(options).unwrap_or_default();
     let chunk_content = format!(
-        "{}|{}|{}|{}",
-        code, options_str, previous_hash, dependencies_hash
+        "{}|{}|{}|{}|{}",
+        code,
+        options_str,
+        previous_hash,
+        dependencies_hash,
+        *crate::SCRIPTS_VERSION,
     );
 
     let mut hasher = Sha256::new();
@@ -41,6 +47,7 @@ pub fn get_chunk_hash(
 /// - Code content
 /// - Options (show, eval, digits)
 /// - Previous inline expression hash (for sequential invalidation)
+/// - Scripts version (same invalidation guarantee as chunk hashes)
 pub fn get_inline_expr_hash(
     code: &str,
     options: &crate::parser::InlineOptions,
@@ -52,7 +59,13 @@ pub fn get_inline_expr_hash(
         "show={:?},eval={},digits={:?}",
         resolved.show, resolved.eval, resolved.digits
     );
-    let inline_content = format!("{}|{}|{}", code, options_str, previous_hash);
+    let inline_content = format!(
+        "{}|{}|{}|{}",
+        code,
+        options_str,
+        previous_hash,
+        *crate::SCRIPTS_VERSION,
+    );
 
     let mut hasher = Sha256::new();
     hasher.update(inline_content.as_bytes());

--- a/crates/knot-core/src/lib.rs
+++ b/crates/knot-core/src/lib.rs
@@ -76,6 +76,25 @@ pub const PYTHON_HELPERS: &[(&str, &str)] = &[
     ("lsp.py", include_str!("../resources/python/lsp.py")),
 ];
 
+/// A short fingerprint of the embedded language scripts (R + Python).
+///
+/// Included in every chunk hash so that updating `output.R` or `output.py`
+/// automatically invalidates all existing cache entries — no manual
+/// `knot clean` required when the runtime scripts change.
+///
+/// Computed once at first access and cached for the lifetime of the process.
+pub static SCRIPTS_VERSION: once_cell::sync::Lazy<String> = once_cell::sync::Lazy::new(|| {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    for (_, content) in R_HELPERS {
+        hasher.update(content.as_bytes());
+    }
+    for (_, content) in PYTHON_HELPERS {
+        hasher.update(content.as_bytes());
+    }
+    format!("{:x}", hasher.finalize())[..16].to_string()
+});
+
 use anyhow::{Context, Result};
 use std::fs;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary

- Adds `SCRIPTS_VERSION`: a 16-char SHA-256 fingerprint of all embedded R and Python helper scripts, computed once per process via `once_cell::Lazy`
- Includes it in both `get_chunk_hash` and `get_inline_expr_hash`
- Any change to the embedded scripts (e.g. updating the SVG filename convention in `output.R`) now automatically invalidates all cache entries — no manual `knot clean` required after upgrades

## Why this was needed

PR #28 changed `output.R` to include dimensions in the SVG filename hash, so that `fig-width` changes produce a new filename and force a fresh read. But existing cache entries (created by the old binary) had chunk hashes identical to what the new binary computes — so they were treated as cache hits, R never re-executed, and the stale filename was reused. Users had to `knot clean` manually after every binary upgrade.

With `SCRIPTS_VERSION` in the chunk hash, changing any embedded script changes all hashes → all entries become cache misses → automatic re-execution.

## Test plan

- [x] Change `fig-width` in a chunk → save → preview updates without `knot clean`
- [x] No regression: unchanged chunks still produce cache hits between saves

🤖 Generated with [Claude Code](https://claude.com/claude-code)