### PR TITLE
feat(core): label/caption redesign — move figure wrapping from Rust to Typst

### DIFF
--- a/crates/knot-core/src/backend.rs
+++ b/crates/knot-core/src/backend.rs
@@ -89,8 +89,7 @@ impl Backend for TypstBackend {
         } else {
             "code-chunk"
         };
-        let call = format!("#{}({})", fn_name, args.join(", "));
-        wrap_with_figure(chunk, &call)
+        format!("#{}({})", fn_name, args.join(", "))
     }
 }
 
@@ -98,14 +97,16 @@ impl Backend for TypstBackend {
 // Private helpers for format_chunk()
 // ---------------------------------------------------------------------------
 
-/// Pushes lang, name/caption, is-inert, and parse errors into `args`.
+/// Pushes lang, label/caption, is-inert, and parse errors into `args`.
 fn push_base_args(chunk: &Chunk, state: &ChunkExecutionState, args: &mut Vec<String>) {
     args.push(format!("lang: \"{}\"", chunk.language));
 
-    if let Some(name) = &chunk.name {
-        args.push(format!("name: \"{}\"", name));
-    } else if let Some(caption) = &chunk.options.caption {
-        // Only pass caption to code-chunk if there is no name wrapper (no figure)
+    if let Some(label) = &chunk.label
+        && !label.trim().is_empty()
+    {
+        args.push(format!("label: \"{}\"", label));
+    }
+    if let Some(caption) = &chunk.options.caption {
         args.push(format!("caption: [{}]", caption));
     }
 
@@ -308,24 +309,6 @@ fn push_presentation_args(resolved_options: &ResolvedChunkOptions, args: &mut Ve
     }
 }
 
-/// Wraps `code_chunk_call` in a #figure() with label when the chunk has a non-empty name.
-fn wrap_with_figure(chunk: &Chunk, code_chunk_call: &str) -> String {
-    if let Some(name) = &chunk.name
-        && !name.trim().is_empty()
-    {
-        let mut figure_args = vec!["kind: raw".to_string(), "supplement: \"Chunk\"".to_string()];
-        if let Some(caption) = &chunk.options.caption {
-            figure_args.push(format!("caption: [{}]", caption));
-        }
-        return format!(
-            "#figure({})[{}]\n <{}>",
-            figure_args.join(", "),
-            code_chunk_call,
-            name.trim()
-        );
-    }
-    code_chunk_call.to_string()
-}
 
 #[cfg(test)]
 mod tests {
@@ -351,7 +334,7 @@ mod tests {
     fn create_test_chunk(
         language: &str,
         code: &str,
-        name: Option<String>,
+        label: Option<String>,
         show: Show,
         caption: Option<String>,
     ) -> Chunk {
@@ -364,7 +347,7 @@ mod tests {
             index: 0, // Dummy chunk for test/inline contexts
             language: language.to_string(),
             code: code.to_string(),
-            name,
+            label,
             base_indentation: String::new(),
             options: ChunkOptions {
                 eval: Some(true),

--- a/crates/knot-core/src/backend.rs
+++ b/crates/knot-core/src/backend.rs
@@ -309,7 +309,6 @@ fn push_presentation_args(resolved_options: &ResolvedChunkOptions, args: &mut Ve
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/knot-core/src/compiler/execution.rs
+++ b/crates/knot-core/src/compiler/execution.rs
@@ -337,7 +337,7 @@ fn cache_chunk_error(
     {
         cache.lock().unwrap().save_error(
             chunk.index,
-            chunk.name.clone(),
+            chunk.label.clone(),
             chunk.language.clone(),
             pn.hash.clone(),
             error.clone(),
@@ -358,7 +358,7 @@ fn cache_chunk_result(
     {
         cache.lock().unwrap().save_result(
             chunk.index,
-            chunk.name.clone(),
+            chunk.label.clone(),
             chunk.language.clone(),
             pn.hash.clone(),
             output,

--- a/crates/knot-core/src/compiler/freeze.rs
+++ b/crates/knot-core/src/compiler/freeze.rs
@@ -31,7 +31,7 @@ pub(super) fn register_freeze_objects(
     cache: &Arc<Mutex<Cache>>,
     project_root: &Path,
 ) -> Result<()> {
-    let chunk_name = chunk.name.as_deref().unwrap_or("unnamed").to_string();
+    let chunk_name = chunk.label.as_deref().unwrap_or("unnamed").to_string();
     let cache_dir = project_root.join(Defaults::CACHE_DIR_NAME);
 
     for obj_name in &chunk.options.freeze {
@@ -103,7 +103,7 @@ pub(super) fn check_freeze_contract(
     }
 
     let chunk_name = match &pn.kind {
-        PlannedNodeKind::Chunk { node, .. } => node.name.as_deref().unwrap_or("unnamed"),
+        PlannedNodeKind::Chunk { node, .. } => node.label.as_deref().unwrap_or("unnamed"),
         PlannedNodeKind::Inline { .. } => "inline",
     };
 

--- a/crates/knot-core/src/compiler/mod.rs
+++ b/crates/knot-core/src/compiler/mod.rs
@@ -211,7 +211,7 @@ impl Compiler {
                     let (chunk_options, resolved_options, merged_codly_options) =
                         resolve_options(&chunk, &self.config, &ChunkExecutionState::Ready);
                     let name = chunk
-                        .name
+                        .label
                         .as_deref()
                         .map(String::from)
                         .unwrap_or_else(|| format!("chunk-{}", chunk.index));
@@ -585,7 +585,7 @@ pub(super) mod test_helpers {
             index: 0,
             language: language.to_string(),
             code: code.to_string(),
-            name,
+            label: name,
             base_indentation: String::new(),
             options: ChunkOptions {
                 eval: Some(eval),

--- a/crates/knot-core/src/compiler/node_output.rs
+++ b/crates/knot-core/src/compiler/node_output.rs
@@ -96,7 +96,9 @@ pub(super) fn format_error_block_for_node(
 ) -> String {
     let error_msg = error_msg.replace('"', "\\\"");
     let (node_kind, node_name) = match kind {
-        PlannedNodeKind::Chunk { node, .. } => ("chunk", node.label.as_deref().unwrap_or("unnamed")),
+        PlannedNodeKind::Chunk { node, .. } => {
+            ("chunk", node.label.as_deref().unwrap_or("unnamed"))
+        }
         PlannedNodeKind::Inline { .. } => ("inline expression", "inline"),
     };
     format!(

--- a/crates/knot-core/src/compiler/node_output.rs
+++ b/crates/knot-core/src/compiler/node_output.rs
@@ -96,7 +96,7 @@ pub(super) fn format_error_block_for_node(
 ) -> String {
     let error_msg = error_msg.replace('"', "\\\"");
     let (node_kind, node_name) = match kind {
-        PlannedNodeKind::Chunk { node, .. } => ("chunk", node.name.as_deref().unwrap_or("unnamed")),
+        PlannedNodeKind::Chunk { node, .. } => ("chunk", node.label.as_deref().unwrap_or("unnamed")),
         PlannedNodeKind::Inline { .. } => ("inline expression", "inline"),
     };
     format!(

--- a/crates/knot-core/src/parser/ast.rs
+++ b/crates/knot-core/src/parser/ast.rs
@@ -391,7 +391,7 @@ define_options! {
 pub struct Chunk {
     pub index: usize, // Ordinal position in document (0-based)
     pub language: String,
-    pub name: Option<String>,
+    pub label: Option<String>,
     pub code: String,
     pub base_indentation: String,
     pub options: ChunkOptions,
@@ -413,12 +413,12 @@ impl Chunk {
     pub fn format(&self, formatted_code: Option<&str>, indentation: Option<&str>) -> String {
         let mut out = String::new();
 
-        // 1. Header: ```{lang name}
+        // 1. Header: ```{lang label}
         out.push_str("```{");
         out.push_str(&self.language);
-        if let Some(name) = self.name.as_deref().filter(|n| !n.trim().is_empty()) {
+        if let Some(label) = self.label.as_deref().filter(|n| !n.trim().is_empty()) {
             out.push(' ');
-            out.push_str(name);
+            out.push_str(label);
         }
         out.push_str("}\n");
 

--- a/crates/knot-core/src/parser/winnow_parser.rs
+++ b/crates/knot-core/src/parser/winnow_parser.rs
@@ -123,7 +123,7 @@ pub fn parse_document(source: &str) -> Document {
                     chunks.push(Chunk {
                         index: chunk_index,
                         language: lang.to_string(),
-                        name: extract_name(header, n),
+                        label: extract_name(header, n),
                         code,
                         base_indentation: base_indent,
                         options,

--- a/crates/knot-core/src/snapshots/knot_core__backend__tests__format_chunk_empty_name_no_figure_wrapper.snap
+++ b/crates/knot-core/src/snapshots/knot_core__backend__tests__format_chunk_empty_name_no_figure_wrapper.snap
@@ -2,6 +2,6 @@
 source: crates/knot-core/src/backend.rs
 expression: "backend.format_chunk(&chunk, &chunk.codly_options, &resolved, &output_data,\n&ChunkExecutionState::Ready)"
 ---
-#code-chunk(lang: "r", name: "", code: [```r
+#code-chunk(lang: "r", code: [```r
 1 + 1```], output: [```output
 [1] 2```], layout: "horizontal")

--- a/crates/knot-core/src/snapshots/knot_core__backend__tests__format_chunk_with_name_and_caption.snap
+++ b/crates/knot-core/src/snapshots/knot_core__backend__tests__format_chunk_with_name_and_caption.snap
@@ -2,7 +2,6 @@
 source: crates/knot-core/src/backend.rs
 expression: "backend.format_chunk(&chunk, &chunk.codly_options, &resolved, &output_data,\n&ChunkExecutionState::Ready)"
 ---
-#figure(kind: raw, supplement: "Chunk", caption: [[My Caption]])[#code-chunk(lang: "r", name: "my-chunk", code: [```r
+#code-chunk(lang: "r", label: "my-chunk", caption: [[My Caption]], code: [```r
 x <- 1:10```], output: [```output
-[1] 1  2  3  4  5  6  7  8  9 10```], layout: "horizontal")]
- <my-chunk>
+[1] 1  2  3  4  5  6  7  8  9 10```], layout: "horizontal")

--- a/crates/knot-core/tests/integration_basic.rs
+++ b/crates/knot-core/tests/integration_basic.rs
@@ -44,7 +44,7 @@ Done!
 
     // Verify we parsed the chunk
     assert_eq!(doc.chunks.len(), 1);
-    assert_eq!(doc.chunks[0].name, Some("test".to_string()));
+    assert_eq!(doc.chunks[0].label, Some("test".to_string()));
     assert_eq!(doc.chunks[0].options.eval, Some(true));
     assert_eq!(
         doc.chunks[0].options.show,
@@ -80,9 +80,9 @@ print(y)
     let doc = Document::parse(source);
 
     assert_eq!(doc.chunks.len(), 3);
-    assert_eq!(doc.chunks[0].name, Some("setup".to_string()));
-    assert_eq!(doc.chunks[1].name, Some("compute".to_string()));
-    assert_eq!(doc.chunks[2].name, Some("output".to_string()));
+    assert_eq!(doc.chunks[0].label, Some("setup".to_string()));
+    assert_eq!(doc.chunks[1].label, Some("compute".to_string()));
+    assert_eq!(doc.chunks[2].label, Some("output".to_string()));
 }
 
 #[test]
@@ -99,7 +99,7 @@ x <- 5
     let doc = Document::parse(source);
 
     assert_eq!(doc.chunks.len(), 1);
-    assert_eq!(doc.chunks[0].name, None);
+    assert_eq!(doc.chunks[0].label, None);
 }
 
 #[test]

--- a/crates/knot-lsp/src/handlers/hover.rs
+++ b/crates/knot-lsp/src/handlers/hover.rs
@@ -29,7 +29,7 @@ pub async fn handle_hover(state: &ServerState, params: HoverParams) -> Result<Op
     if let Some(chunk) = current_chunk {
         // Skip fence lines
         if line == chunk.range.start.line || line == chunk.range.end.line {
-            let name = chunk.name.as_deref().unwrap_or("unnamed");
+            let name = chunk.label.as_deref().unwrap_or("unnamed");
             let content = format!(
                 "### Knot Chunk: `{}`\n- **Language**: `{}`",
                 name, chunk.language

--- a/crates/knot-lsp/src/symbols.rs
+++ b/crates/knot-lsp/src/symbols.rs
@@ -17,7 +17,7 @@ pub fn get_document_symbols(text: &str) -> Option<Vec<DocumentSymbol>> {
     for chunk in &doc.chunks {
         // Create a symbol for each chunk
         let name = chunk
-            .name
+            .label
             .clone()
             .unwrap_or_else(|| format!("Unnamed {} chunk", chunk.language));
 

--- a/knot-typst-package/lib.typ
+++ b/knot-typst-package/lib.typ
@@ -14,6 +14,13 @@
 // not document configuration (Codly, figure numbering, etc.).
 // Document configuration belongs in your main.knot file.
 
+/// Default configuration for chunk figure presentation.
+/// Override in your document to change supplement text, e.g.:
+///   #let knot-chunk-defaults = (supplement: "Fragment")
+#let knot-chunk-defaults = (
+  supplement: "Chunk",
+)
+
 /// Visual styles for chunk execution states (live preview only — not in final PDF).
 /// These appear during `knot watch --preview` and VS Code preview when chunks are
 /// pending execution, recently modified, or inert due to an upstream error.
@@ -42,6 +49,8 @@
 #let code-chunk(
   code: none,
   output: none,
+  label: none,
+  caption: none,
   warnings: (),
   errors: (),
   warnings-position: "below", // "below" or "inline"
@@ -171,7 +180,7 @@
   // Warnings below: appended after main-content (inline: already embedded above)
   let below-warnings = if warnings-position == "inline" { () } else { warning-blocks }
 
-  stack(
+  let body = stack(
     dir: ttb,
     spacing: 0.5em,
     main-content,
@@ -187,6 +196,19 @@
       #e
     ]),
   )
+
+  // Wrap in #figure() when a label or caption is provided
+  if label != none or caption != none {
+    figure(
+      body,
+      kind: raw,
+      supplement: knot-chunk-defaults.supplement,
+      caption: caption,
+    )
+    if label != none { std.label(label) }
+  } else {
+    body
+  }
 }
 
 /// Presentation replacement: shows code on overlay 1, output on overlay 2


### PR DESCRIPTION
Closes #21

## Summary

- **`Chunk.name` → `Chunk.label`** in `parser/ast.rs` — clarifies that this identifier is a Typst cross-reference label, not a display name
- **Remove `wrap_with_figure` from `backend.rs`** — the Rust backend now passes `label:` and `caption:` as named args to `#code-chunk()`, without any `#figure()` wrapping
- **`lib.typ` owns figure presentation** — `code-chunk` wraps in `#figure(kind: raw, supplement: knot-chunk-defaults.supplement, caption: caption)` + `std.label(label)` when a label or caption is provided
- **`knot-chunk-defaults`** dict added to `lib.typ` (default `supplement: "Chunk"`) — fully configurable from Typst without touching `knot.toml`

`label` and `caption` are now independent: a chunk can have a caption without a label (figure without cross-ref) or a label without a caption.

## Test plan

- [x] `cargo test --workspace --exclude knot-cli` — all tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Insta snapshots updated to reflect new `#code-chunk(label: ..., caption: ...)` output
- [ ] Manual test: chunk with `label` renders as a numbered figure with `@label` cross-ref working in Typst

🤖 Generated with [Claude Code](https://claude.com/claude-code)